### PR TITLE
Fix db connectors

### DIFF
--- a/controllers/views.js
+++ b/controllers/views.js
@@ -24,6 +24,7 @@ async function getSheets(userId = null, type = null, filterActive = false, group
       t.type_api_name as typeApi,
       t.type_name as typeName,
       d.db_name as dbName,
+      d.db_type as dbType,
       d.connection_string as dbString
     FROM views v
     JOIN views_types t


### PR DESCRIPTION
Fixed an error in the getSheets function in ./controllers/views.js .
The db_type field was missing, causing error in the reloadData function.